### PR TITLE
Fix: Use .toArrayLike(Buffer) instead of .toBuffer() in utils.crypto

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -11,7 +11,7 @@ export const hash = function(input: string | Buffer): string {
 
 export const sign = function(hash: Buffer, privateKey: Buffer): string {
   const signature = secp256k1.keyFromPrivate(privateKey).sign(hash, { canonical: true });
-  return "0x" + Buffer.concat([signature.r.toBuffer(), signature.s.toBuffer(), Buffer.from([signature.recoveryParam])]).toString("hex"); /* tslint:disable:max-line-length */
+  return "0x" + Buffer.concat([signature.r.toArrayLike(Buffer), signature.s.toArrayLike(Buffer), Buffer.from([signature.recoveryParam])]).toString("hex"); /* tslint:disable:max-line-length */
 };
 
 export const recover = function(hash: Buffer, sig: Buffer): string {


### PR DESCRIPTION
.toBuffer() leads to an assertion failure when using tools like Browserify/Webpack as mentioned in https://github.com/indutny/bn.js#utilities - which always leads to an error being thrown on calling web3.eth.accounts.sign()

Replacing .toBuffer() with .toArrayLike(Buffer) leads to the same results and returns a signed message as intended without errors when using Browserify, Webpack etc.