### PR TITLE
Update hashMessage to VIP-190

### DIFF
--- a/src/extend/accounts.ts
+++ b/src/extend/accounts.ts
@@ -115,8 +115,11 @@ const extendAccounts = function(web3: any): any {
     web3.eth.accounts.hashMessage = function hashMessage(data: string | Buffer) {
         const message = web3Utils.isHexStrict(data) ? web3Utils.hexToBytes(data) : data
         const messageBuffer = Buffer.from(message)
+        const prefix = '\u0019VeChain Signed Message:\n' + message.length.toString()
+        const prefixBuffer = Buffer.from(prefix)
+        const prefixedMessage = Buffer.concat([prefixBuffer, messageBuffer])
 
-        return utils.toPrefixedHex(cry.blake2b256(messageBuffer).toString('hex'))
+        return utils.toPrefixedHex(cry.blake2b256(prefixedMessage).toString('hex'))
     }
 
     web3.eth.accounts.sign = function sign(data: string | Buffer, privateKey: string) {

--- a/test/extend/accounts.test.ts
+++ b/test/extend/accounts.test.ts
@@ -227,25 +227,25 @@ describe('extend:accounts', () => {
 
     it('hash message', async () => {
         const message = 'test message'
-        expect(web3.eth.accounts.hashMessage(message)).to.be.equal('0xf1d201623965f4a21390705e83ba1fb2c33600a529bd2fab2373c2558bf4cb5e')
+        expect(web3.eth.accounts.hashMessage(message)).to.be.equal('0x6bb54cc20ea49203c24ece6c631f81f35cf947b136246dc0de006609d294b032')
     })
 
     it('hash message with hexadecimal string', async () => {
         const message = '0x74657374206d657373616765'
-        expect(web3.eth.accounts.hashMessage(message)).to.be.equal('0xf1d201623965f4a21390705e83ba1fb2c33600a529bd2fab2373c2558bf4cb5e')
+        expect(web3.eth.accounts.hashMessage(message)).to.be.equal('0x6bb54cc20ea49203c24ece6c631f81f35cf947b136246dc0de006609d294b032')
     })
 
     it('sign message', async () => {
         const message = 'test message'
         const ret = web3.eth.accounts.sign(message, '0xdce1443bd2ef0c2631adc1c67e5c93f13dc23a41c18b536effbbdcbcdb96fb65')
         expect(ret.message).to.be.equal('test message')
-        expect(ret.messageHash).to.be.equal('0xf1d201623965f4a21390705e83ba1fb2c33600a529bd2fab2373c2558bf4cb5e')
-        expect(ret.signature).to.be.equal('0xce639afc9733cbffe7a2dd87e096856e5a81fc5094c9292919eb04eb9a751b7747986f7351d562a64b9b9c9d7989eec344570e754b0461a34bb598c1ee262aef00')
+        expect(ret.messageHash).to.be.equal('0x6bb54cc20ea49203c24ece6c631f81f35cf947b136246dc0de006609d294b032')
+        expect(ret.signature).to.be.equal('0x9fd2e0f9b57405809fcb52887e62ac17abd2a94112ec272ee606589ea6da956b3cbfc7386e9e9383dced85f85386dcea401f82bba529f5a5452512985598388400')
     })
 
     it('recover with not-prefixed message', async () => {
         const message = 'test message'
-        const signature = '0xce639afc9733cbffe7a2dd87e096856e5a81fc5094c9292919eb04eb9a751b7747986f7351d562a64b9b9c9d7989eec344570e754b0461a34bb598c1ee262aef00'
+        const signature = '0x9fd2e0f9b57405809fcb52887e62ac17abd2a94112ec272ee606589ea6da956b3cbfc7386e9e9383dced85f85386dcea401f82bba529f5a5452512985598388400'
         expect(web3.eth.accounts.recover(message, signature)).to.be.equal('0x7567d83b7b8d80addcb281a71d54fc7b3364ffed')
     })
 


### PR DESCRIPTION
Updates thorify's `web3.eth.accounts.hashMessage` implementation to be consistent with [VIP-190](https://github.com/vechain/VIPs/pull/3).

This allows `web3.eth.accounts.recover` to work correctly with other implementation of personal sign (Comet, Ledger, Address Binding).